### PR TITLE
-e ansible_python_interpreter=$(which python)

### DIFF
--- a/documentation/modules/ROOT/pages/03-demo.adoc
+++ b/documentation/modules/ROOT/pages/03-demo.adoc
@@ -161,7 +161,7 @@ Run the Ansible script which will setup the RHCL Operator, Cert Manager Operator
 [source,shell script]
 ----
 cd operator-setup 
-ansible-playbook playbooks/ocp4_workload_connectivity_link.yml -e ACTION=create -i inventories/inventory.template
+ansible-playbook playbooks/ocp4_workload_connectivity_link.yml -e ACTION=create -i inventories/inventory.template -e ansible_python_interpreter=$(which python)
 ----
 
 === What's next


### PR DESCRIPTION
I find that adding this flag at the end of the ansible-playbook command eliminates a lot of headache, since some systems have multiple versions of Python on them