### PR TITLE
docs: clarify inventory file setup and fix ansible command path

### DIFF
--- a/documentation/modules/ROOT/pages/03-demo.adoc
+++ b/documentation/modules/ROOT/pages/03-demo.adoc
@@ -117,9 +117,16 @@ git clone https://github.com/rh-soln-pattern-connectivity-link/connectivity-link
 ----
 
 
-* Open the `inventories/inventory.template` file and update the variables. Save the file.
+* Copy the inventory template and edit it with your configuration:
 +
-.[underline]#Click for details of inventory.template file#
+----
+cd operator-setup
+cp inventories/inventory.template inventories/inventory
+----
++
+* Open the `inventories/inventory` file and update the variables with your AWS credentials and cluster details. Save the file.
++
+.[underline]#Click for details of inventory file#
 [%collapsible]
 ====
 ```
@@ -160,8 +167,8 @@ Run the Ansible script which will setup the RHCL Operator, Cert Manager Operator
 [.console-input]
 [source,shell script]
 ----
-cd operator-setup 
-ansible-playbook playbooks/ocp4_workload_connectivity_link.yml -e ACTION=create -i inventories/inventory.template
+cd operator-setup
+ansible-playbook playbooks/ocp4_workload_connectivity_link.yml -e ACTION=create -i inventories/inventory
 ----
 
 === What's next


### PR DESCRIPTION
The inventory file setup instructions were unclear due to:
1. Missing directory context - the path 'inventories/inventory.template' only works after 'cd operator-setup', but the instruction to open the file appeared before the cd command
2. Missing copy step - users should copy the template to avoid editing version-controlled files
3. Wrong filename - ansible-playbook command referenced 'inventory.template' instead of the copied 'inventory' file

Changes:
- Add explicit 'cd operator-setup' before the copy command
- Add 'cp inventories/inventory.template inventories/inventory' command
- Update instructions to reference 'inventory' instead of 'inventory.template'
- Fix ansible-playbook command to use 'inventories/inventory'

This prevents confusion about file paths and follows Git best practices by not editing version-controlled template files.